### PR TITLE
Add corporate insider trade context to daily workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Follow here: https://x.com/theinsidescope
 - **Rich Twitter automation** – Generates engaging single- or multi-trade posts, applies heuristics for tone and hashtags, can
   attach price charts, and retries transient API failures. 【F:src/twitter_client.py†L38-L213】【F:src/twitter_client.py†L421-L658】【F:src/twitter_client.py†L1137-L1177】
 - **Email reporting** – Sends an HTML table that highlights each disclosure for the day, ready to drop into an inbox. 【F:src/emailer.py†L1-L81】
+- **Corporate insider context** – Cross-references FMP's latest insider filings to spotlight overlapping tickers directly in the daily highlights. 【F:src/insider.py†L1-L111】【F:src/emailer.py†L1-L142】【F:src/main.py†L1-L45】
 - **Developer tooling** – Includes a tweet preview script and pytest suite for validating copy, formatting, and Twitter client
   behavior. 【F:scripts/preview_tweet.py†L1-L138】【F:tests/test_twitter_client.py†L1-L150】
 

--- a/src/emailer.py
+++ b/src/emailer.py
@@ -5,7 +5,7 @@ import smtplib
 from email.message import EmailMessage
 from typing import Any, Dict, Iterable, Optional, cast
 
-from insights import build_highlights_html, compute_trade_insights
+from insights import build_highlights_html, compute_trade_insights, summarize_insider_activity
 
 
 def send_summary(new_trades: Iterable[Dict[str, Any]], insights: Optional[Dict[str, Any]] = None) -> None:
@@ -21,6 +21,23 @@ def send_summary(new_trades: Iterable[Dict[str, Any]], insights: Optional[Dict[s
     if insights is None:
         insights = compute_trade_insights(new_trades)
     highlights_html = build_highlights_html(insights)
+
+    insider_section_html = ""
+    insider_activity = {}
+    if insights:
+        insider_activity = insights.get("related_insider_activity") or {}
+    if insider_activity:
+        insider_items = summarize_insider_activity(insider_activity, max_items=5)
+        if insider_items:
+            insider_list = "".join(f"<li>{item}</li>" for item in insider_items)
+            insider_section_html = f"""
+  <div class='insider-insights'>
+    <h3>Corporate Insider Context</h3>
+    <ul>
+      {insider_list}
+    </ul>
+  </div>
+"""
 
     # Check required environment variables
     smtp_host = os.getenv("SMTP_HOST")
@@ -65,6 +82,26 @@ def send_summary(new_trades: Iterable[Dict[str, Any]], insights: Optional[Dict[s
     .highlights li {{
       margin-bottom: 6px;
     }}
+    .insider-insights {{
+      background-color: #fff9f0;
+      border: 1px solid #f4d3a1;
+      border-radius: 6px;
+      padding: 12px 16px;
+      margin-bottom: 18px;
+      line-height: 1.4;
+    }}
+    .insider-insights h3 {{
+      margin: 0 0 8px 0;
+      font-size: 16px;
+      color: #8c5404;
+    }}
+    .insider-insights ul {{
+      margin: 0;
+      padding-left: 20px;
+    }}
+    .insider-insights li {{
+      margin-bottom: 6px;
+    }}
     table {{ border-collapse: collapse; width: 100%; }}
     th, td {{ border: 1px solid #dddddd; text-align: left; padding: 8px; }}
     th {{ background-color: #f2f2f2; }}
@@ -75,6 +112,7 @@ def send_summary(new_trades: Iterable[Dict[str, Any]], insights: Optional[Dict[s
 <body>
   <h2>Daily Congressional Trades Summary</h2>
   {highlights_html}
+  {insider_section_html}
   <table>
     <tr>
       <th>Disclosure Date</th>

--- a/src/insider.py
+++ b/src/insider.py
@@ -1,0 +1,142 @@
+"""Helpers for enriching congressional trades with corporate insider activity."""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+import requests
+from dotenv import load_dotenv
+
+# Ensure environment variables are loaded for local runs
+load_dotenv()
+
+API_KEY = os.getenv("FMP_API_KEY")
+BASE_URL = "https://financialmodelingprep.com"
+
+
+def fetch_latest_insider_trades(limit: int = 250) -> List[Dict[str, Any]]:
+    """Fetch the latest corporate insider trading disclosures from FMP.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of insider trade records to request. The API currently
+        supports up to 1,000 items per call. Smaller limits reduce payload size
+        when running locally.
+    """
+
+    if not API_KEY:
+        print("[Insider] Skipping fetch_latest_insider_trades: FMP_API_KEY is not set")
+        return []
+
+    url = f"{BASE_URL}/stable/insider-trading/latest?page=0&limit={limit}&apikey={API_KEY}"
+    try:
+        response = requests.get(url, timeout=15)
+    except Exception as exc:  # pragma: no cover - defensive logging only
+        print(f"[Insider] Request failed: {exc}")
+        return []
+
+    if response.status_code != 200:
+        print(
+            "[Insider] Unexpected status code",
+            response.status_code,
+            response.text[:200],
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError:
+        print("[Insider] Failed to decode JSON response")
+        return []
+
+    if isinstance(payload, list):
+        return payload
+
+    print("[Insider] Unexpected payload type", type(payload))
+    return []
+
+
+def find_recent_insider_activity(
+    trades: Iterable[Mapping[str, Any]],
+    *,
+    lookback_days: int = 14,
+    insider_limit: int = 500,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Return insider trading activity that overlaps the provided trades.
+
+    The function fetches a batch of the most recent corporate insider filings
+    and filters for entries that share a ticker symbol with the congressional
+    trades within the provided lookback window.
+    """
+
+    trades = list(trades)
+    if not trades:
+        return {}
+
+    insider_trades = fetch_latest_insider_trades(limit=insider_limit)
+    if not insider_trades:
+        return {}
+
+    # Build lookup for target symbols and most recent relevant dates
+    target_symbols: Dict[str, datetime] = {}
+    for trade in trades:
+        symbol = (trade.get("symbol") or "").strip().upper()
+        if not symbol:
+            continue
+        try:
+            disclosure_date = datetime.strptime(trade.get("disclosureDate"), "%Y-%m-%d")
+        except Exception:
+            disclosure_date = None
+        try:
+            transaction_date = datetime.strptime(trade.get("transactionDate"), "%Y-%m-%d")
+        except Exception:
+            transaction_date = None
+
+        relevant_date = disclosure_date or transaction_date
+        if relevant_date is None:
+            continue
+
+        # Track the most recent reference date per symbol
+        if symbol not in target_symbols or relevant_date > target_symbols[symbol]:
+            target_symbols[symbol] = relevant_date
+
+    if not target_symbols:
+        return {}
+
+    cutoff_by_symbol: Dict[str, datetime] = {
+        symbol: date - timedelta(days=lookback_days) for symbol, date in target_symbols.items()
+    }
+
+    related: MutableMapping[str, List[Dict[str, Any]]] = defaultdict(list)
+
+    for insider_trade in insider_trades:
+        symbol = (insider_trade.get("symbol") or "").strip().upper()
+        if symbol not in target_symbols:
+            continue
+
+        raw_date = (
+            insider_trade.get("transactionDate")
+            or insider_trade.get("filingDate")
+            or insider_trade.get("date")
+        )
+        try:
+            trade_date = datetime.strptime(raw_date, "%Y-%m-%d") if raw_date else None
+        except Exception:
+            trade_date = None
+
+        if trade_date is None:
+            # Include undated filings as long as we have a symbol match; these are
+            # rare but occasionally present in the API.
+            related[symbol].append(insider_trade)
+            continue
+
+        if trade_date < cutoff_by_symbol[symbol]:
+            continue
+
+        related[symbol].append(insider_trade)
+
+    return {symbol: entries for symbol, entries in related.items() if entries}

--- a/src/insights.py
+++ b/src/insights.py
@@ -1,6 +1,7 @@
 """Utility functions for extracting high-level insights from trade data."""
 
 from collections import Counter, defaultdict
+from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from amounts import parse_amount
@@ -120,6 +121,19 @@ def build_highlights_html(insights: Dict[str, Any]) -> str:
             f"<strong>Most popular ticker:</strong> {ticker_symbol} ({count} trade{'s' if count != 1 else ''}, ~{_format_currency(volume)})"
         )
 
+    insider_activity = insights.get("related_insider_activity") or {}
+    if insider_activity:
+        overlap_count = len(insider_activity)
+        detail_strings = summarize_insider_activity(insider_activity)
+        detail_suffix = f" {', '.join(detail_strings)}" if detail_strings else ""
+        highlights.append(
+            (
+                f"<strong>Insider overlap:</strong> {overlap_count} ticker"
+                f"{'s' if overlap_count != 1 else ''} also saw corporate insider trades"
+                f" in the last two weeks.{detail_suffix}"
+            )
+        )
+
     highlight_items = "".join(f"<li>{item}</li>" for item in highlights)
 
     return (
@@ -170,4 +184,103 @@ def build_highlights_text(insights: Dict[str, Any]) -> str:
             f"Most popular ticker: {ticker_symbol} ({count} trade{'s' if count != 1 else ''}, ~{_format_currency(volume)})"
         )
 
+    insider_activity = insights.get("related_insider_activity") or {}
+    if insider_activity:
+        overlap_count = len(insider_activity)
+        detail_strings = summarize_insider_activity(insider_activity)
+        detail_suffix = f" Details: {', '.join(detail_strings)}" if detail_strings else ""
+        lines.append(
+            (
+                f"Insider overlap: {overlap_count} ticker"
+                f"{'s' if overlap_count != 1 else ''} also saw corporate insider trades"
+                f" in the last two weeks.{detail_suffix}"
+            )
+        )
+
     return "\n".join(lines)
+
+
+def summarize_insider_activity(
+    insider_activity: Dict[str, List[Dict[str, Any]]],
+    *,
+    max_items: int = 3,
+) -> List[str]:
+    """Return short textual summaries of insider trades for highlight sections."""
+
+    def _parse_date(entry: Dict[str, Any]) -> Optional[datetime]:
+        for key in ("transactionDate", "filingDate", "date"):
+            value = entry.get(key)
+            if not value:
+                continue
+            try:
+                return datetime.strptime(value, "%Y-%m-%d")
+            except Exception:
+                continue
+        return None
+
+    def _format_shares(raw_value: Any) -> Optional[str]:
+        if raw_value in (None, ""):
+            return None
+        try:
+            shares = float(raw_value)
+        except (TypeError, ValueError):
+            return str(raw_value)
+        if shares >= 1_000_000:
+            return f"{shares / 1_000_000:.1f}M sh"
+        if shares >= 1_000:
+            return f"{shares / 1_000:.1f}K sh"
+        if shares.is_integer():
+            return f"{int(shares)} sh"
+        return f"{shares:.0f} sh"
+
+    def _format_price(raw_value: Any) -> Optional[str]:
+        if raw_value in (None, ""):
+            return None
+        try:
+            price = float(raw_value)
+        except (TypeError, ValueError):
+            return str(raw_value)
+        return f"${price:,.2f}"
+
+    entries: List[Tuple[datetime, str, Dict[str, Any]]] = []
+    for symbol, trades in insider_activity.items():
+        if not trades:
+            continue
+        # Choose the most recent trade per symbol for highlighting
+        latest_trade = max(trades, key=lambda item: _parse_date(item) or datetime.min)
+        entries.append((_parse_date(latest_trade) or datetime.min, symbol, latest_trade))
+
+    # Sort descending by date so the freshest intel appears first
+    entries.sort(key=lambda item: item[0], reverse=True)
+
+    summaries: List[str] = []
+    for _, symbol, trade in entries[:max_items]:
+        name = trade.get("insiderName") or trade.get("reportingName") or "Insider"
+        title = trade.get("insiderTitle") or trade.get("position") or trade.get("typeOfOwner")
+        action = trade.get("transactionType") or trade.get("type") or "trade"
+        date = trade.get("transactionDate") or trade.get("filingDate") or "recently"
+        shares = _format_shares(
+            trade.get("securitiesTransacted")
+            or trade.get("shares")
+            or trade.get("securities")
+            or trade.get("sharesTraded")
+        )
+        price = _format_price(trade.get("price") or trade.get("sharePrice"))
+
+        descriptor = name.strip()
+        if title:
+            descriptor = f"{descriptor} ({title})"
+
+        details: List[str] = [descriptor, action.strip(), date]
+        meta: List[str] = []
+        if shares:
+            meta.append(shares)
+        if price:
+            meta.append(price)
+
+        if meta:
+            details.append(f"[{', '.join(meta)}]")
+
+        summaries.append(f"{symbol}: {' '.join(details)}")
+
+    return summaries

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,8 @@ from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 
 from emailer import send_summary
-from insights import build_highlights_text, compute_trade_insights
+from insider import find_recent_insider_activity
+from insights import build_highlights_text, compute_trade_insights, summarize_insider_activity
 from notifier import run_delta
 from twitter_client import post_trades_to_twitter
 
@@ -24,9 +25,17 @@ def main():
     print(f"Found {len(trades_today)} trades disclosed today ({today})")
     
     if trades_today:
+        insider_activity = find_recent_insider_activity(trades_today)
         insights = compute_trade_insights(trades_today)
+        if insider_activity:
+            insights["related_insider_activity"] = insider_activity
         print("Daily highlights:")
         print(build_highlights_text(insights))
+
+        if insider_activity:
+            print("Related corporate insider activity:")
+            for line in summarize_insider_activity(insider_activity):
+                print(f"  - {line}")
 
         # Send email summary
         print("Sending email...")


### PR DESCRIPTION
## Summary
- add an insider-trading client that pulls recent FMP filings and matches them to congressional tickers
- surface overlapping corporate insider activity in the daily highlights, logs, and HTML email
- document the new context capability in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f981cd7c10832eae96909d47021cd2